### PR TITLE
PR: Seperation of Multicast and Federation Connection Statuses

### DIFF
--- a/api/v1alpha1/cloudinstance_types.go
+++ b/api/v1alpha1/cloudinstance_types.go
@@ -63,7 +63,7 @@ type CloudInstanceStatus struct {
 //+kubebuilder:printcolumn:name="Gateway",type=string,JSONPath=`.status.gatewayConnection.gatewayResource`
 //+kubebuilder:printcolumn:name="Hostname",type=string,JSONPath=`.status.gatewayConnection.hostname`
 //+kubebuilder:printcolumn:name="Cluster ID",type=string,JSONPath=`.status.gatewayConnection.clusterID`
-//+kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+//+kubebuilder:printcolumn:name="Multicast",type=string,JSONPath=`.status.phase`
 
 // CloudInstance is the Schema for the cloudinstances API
 type CloudInstance struct {

--- a/api/v1alpha1/physicalinstance_types.go
+++ b/api/v1alpha1/physicalinstance_types.go
@@ -34,22 +34,38 @@ type FederationMemberInstanceStatus struct {
 }
 
 type PhysicalInstancePhase string
+type PhysicalInstanceMulticastConnectionPhase string
+type PhysicalInstanceFederationConnectionPhase string
 
 const (
-	PhysicalInstancePhaseLookingForDeployer        PhysicalInstancePhase = "LookingForDeployer"
-	PhysicalInstancePhaseWaitingForDeployer        PhysicalInstancePhase = "WaitingForDeployer"
-	PhysicalInstancePhaseRegistered                PhysicalInstancePhase = "Registered"
-	PhysicalInstancePhaseConnectingOverMulticast   PhysicalInstancePhase = "ConnectingOverMulticast"
-	PhysicalInstancePhaseConnectingOverKubernetes  PhysicalInstancePhase = "ConnectingOverKubernetes"
-	PhysicalInstancePhaseConnected                 PhysicalInstancePhase = "Connected"
-	PhysicalInstancePhaseNotConnectedOverMulticast PhysicalInstancePhase = "NotConnectedOverMulticast"
+	PhysicalInstancePhaseLookingForDeployer PhysicalInstancePhase = "LookingForDeployer"
+	PhysicalInstancePhaseWaitingForDeployer PhysicalInstancePhase = "WaitingForDeployer"
+	PhysicalInstancePhaseRegistered         PhysicalInstancePhase = "Registered"
+	PhysicalInstancePhaseConnected          PhysicalInstancePhase = "Connected"
+	PhysicalInstancePhaseNotReady           PhysicalInstancePhase = "NotReady"
+)
+
+const (
+	PhysicalInstanceMulticastConnectionPhaseConnecting PhysicalInstanceMulticastConnectionPhase = "Connecting"
+	PhysicalInstanceMulticastConnectionPhaseConnected  PhysicalInstanceMulticastConnectionPhase = "Connected"
+	PhysicalInstanceMulticastConnectionPhaseFailed     PhysicalInstanceMulticastConnectionPhase = "Failed"
+)
+
+const (
+	PhysicalInstanceFederationConnectionPhaseWaitingForMulticast   PhysicalInstanceFederationConnectionPhase = "WaitingForMulticast"
+	PhysicalInstanceFederationConnectionPhaseWaitingForCredentials PhysicalInstanceFederationConnectionPhase = "WaitingForCredentials"
+	PhysicalInstanceFederationConnectionPhaseConnecting            PhysicalInstanceFederationConnectionPhase = "Connecting"
+	PhysicalInstanceFederationConnectionPhaseConnected             PhysicalInstanceFederationConnectionPhase = "Connected"
+	PhysicalInstanceFederationConnectionPhaseFailed                PhysicalInstanceFederationConnectionPhase = "Failed"
 )
 
 // PhysicalInstanceStatus defines the observed state of PhysicalInstance
 type PhysicalInstanceStatus struct {
-	Submariner       SubmarinerResourceStates       `json:"submariner,omitempty"`
-	FederationMember FederationMemberInstanceStatus `json:"federation,omitempty"`
-	Phase            PhysicalInstancePhase          `json:"phase,omitempty"`
+	Submariner                SubmarinerResourceStates                  `json:"submariner,omitempty"`
+	FederationMember          FederationMemberInstanceStatus            `json:"federation,omitempty"`
+	Phase                     PhysicalInstancePhase                     `json:"phase,omitempty"`
+	MulticastConnectionPhase  PhysicalInstanceMulticastConnectionPhase  `json:"multicastPhase,omitempty"`
+	FederationConnectionPhase PhysicalInstanceFederationConnectionPhase `json:"federationPhase,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -58,6 +74,8 @@ type PhysicalInstanceStatus struct {
 //+kubebuilder:printcolumn:name="Gateway",type=string,JSONPath=`.status.submariner.gatewayConnection.gatewayResource`
 //+kubebuilder:printcolumn:name="Hostname",type=string,JSONPath=`.status.submariner.gatewayConnection.hostname`
 //+kubebuilder:printcolumn:name="Cluster ID",type=string,JSONPath=`.status.submariner.gatewayConnection.clusterID`
+//+kubebuilder:printcolumn:name="Multicast",type=string,JSONPath=`.status.multicastPhase`
+//+kubebuilder:printcolumn:name="Federation",type=string,JSONPath=`.status.federationPhase`
 //+kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 
 // PhysicalInstance is the Schema for the physicalinstances API

--- a/api/v1alpha1/physicalinstance_types.go
+++ b/api/v1alpha1/physicalinstance_types.go
@@ -46,9 +46,10 @@ const (
 )
 
 const (
-	PhysicalInstanceMulticastConnectionPhaseConnecting PhysicalInstanceMulticastConnectionPhase = "Connecting"
-	PhysicalInstanceMulticastConnectionPhaseConnected  PhysicalInstanceMulticastConnectionPhase = "Connected"
-	PhysicalInstanceMulticastConnectionPhaseFailed     PhysicalInstanceMulticastConnectionPhase = "Failed"
+	PhysicalInstanceMulticastConnectionPhaseWaitingForConnection PhysicalInstanceMulticastConnectionPhase = "WaitingForConnection"
+	PhysicalInstanceMulticastConnectionPhaseConnecting           PhysicalInstanceMulticastConnectionPhase = "Connecting"
+	PhysicalInstanceMulticastConnectionPhaseConnected            PhysicalInstanceMulticastConnectionPhase = "Connected"
+	PhysicalInstanceMulticastConnectionPhaseFailed               PhysicalInstanceMulticastConnectionPhase = "Failed"
 )
 
 const (

--- a/config/crd/bases/connection-hub.roboscale.io_physicalinstances.yaml
+++ b/config/crd/bases/connection-hub.roboscale.io_physicalinstances.yaml
@@ -25,6 +25,12 @@ spec:
     - jsonPath: .status.submariner.gatewayConnection.clusterID
       name: Cluster ID
       type: string
+    - jsonPath: .status.multicastPhase
+      name: Multicast
+      type: string
+    - jsonPath: .status.federationPhase
+      name: Federation
+      type: string
     - jsonPath: .status.phase
       name: Phase
       type: string
@@ -100,6 +106,10 @@ spec:
                         type: string
                     type: object
                 type: object
+              federationPhase:
+                type: string
+              multicastPhase:
+                type: string
               phase:
                 type: string
               submariner:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/connection-hub-controller-manager-dev
-  newTag: v0.3.8
+  newTag: v0.3.12


### PR DESCRIPTION
# :herb: PR: Seperation of Multicast and Federation Connection Statuses

## Description

For physical instances, multicast and federation connection phases are migrated to seperated fields.

Closes #42 