### PR TITLE
PR: Sub-State to Add Federation Member Credentials

### DIFF
--- a/api/v1alpha1/cloudinstance_types.go
+++ b/api/v1alpha1/cloudinstance_types.go
@@ -63,7 +63,7 @@ type CloudInstanceStatus struct {
 //+kubebuilder:printcolumn:name="Gateway",type=string,JSONPath=`.status.gatewayConnection.gatewayResource`
 //+kubebuilder:printcolumn:name="Hostname",type=string,JSONPath=`.status.gatewayConnection.hostname`
 //+kubebuilder:printcolumn:name="Cluster ID",type=string,JSONPath=`.status.gatewayConnection.clusterID`
-//+kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+//+kubebuilder:printcolumn:name="Multicast",type=string,JSONPath=`.status.phase`
 
 // CloudInstance is the Schema for the cloudinstances API
 type CloudInstance struct {

--- a/api/v1alpha1/federationmember_types.go
+++ b/api/v1alpha1/federationmember_types.go
@@ -18,11 +18,12 @@ type FederationMemberSpec struct {
 type FederationMemberPhase string
 
 const (
-	FederationMemberPhaseSearchingForHost  FederationMemberPhase = "SearchingForHost"
-	FederationMemberPhaseJoiningFederation FederationMemberPhase = "JoiningFederation"
-	FederationMemberPhaseOffline           FederationMemberPhase = "Offline"
-	FederationMemberPhaseReady             FederationMemberPhase = "Ready"
-	FederationMemberPhaseMalfunctioned     FederationMemberPhase = "Malfunctioned"
+	FederationMemberPhaseSearchingForHost      FederationMemberPhase = "SearchingForHost"
+	FederationMemberPhaseWaitingForCredentials FederationMemberPhase = "WaitingForCredentials"
+	FederationMemberPhaseJoiningFederation     FederationMemberPhase = "JoiningFederation"
+	FederationMemberPhaseOffline               FederationMemberPhase = "Offline"
+	FederationMemberPhaseReady                 FederationMemberPhase = "Ready"
+	FederationMemberPhaseMalfunctioned         FederationMemberPhase = "Malfunctioned"
 
 	FederationMemberPhaseCannotJoinFederation FederationMemberPhase = "CannotJoinFederation"
 	FederationMemberPhaseUnjoiningFederation  FederationMemberPhase = "UnjoiningFederation"

--- a/api/v1alpha1/physicalinstance_types.go
+++ b/api/v1alpha1/physicalinstance_types.go
@@ -34,22 +34,39 @@ type FederationMemberInstanceStatus struct {
 }
 
 type PhysicalInstancePhase string
+type PhysicalInstanceMulticastConnectionPhase string
+type PhysicalInstanceFederationConnectionPhase string
 
 const (
-	PhysicalInstancePhaseLookingForDeployer        PhysicalInstancePhase = "LookingForDeployer"
-	PhysicalInstancePhaseWaitingForDeployer        PhysicalInstancePhase = "WaitingForDeployer"
-	PhysicalInstancePhaseRegistered                PhysicalInstancePhase = "Registered"
-	PhysicalInstancePhaseConnectingOverMulticast   PhysicalInstancePhase = "ConnectingOverMulticast"
-	PhysicalInstancePhaseConnectingOverKubernetes  PhysicalInstancePhase = "ConnectingOverKubernetes"
-	PhysicalInstancePhaseConnected                 PhysicalInstancePhase = "Connected"
-	PhysicalInstancePhaseNotConnectedOverMulticast PhysicalInstancePhase = "NotConnectedOverMulticast"
+	PhysicalInstancePhaseLookingForDeployer PhysicalInstancePhase = "LookingForDeployer"
+	PhysicalInstancePhaseWaitingForDeployer PhysicalInstancePhase = "WaitingForDeployer"
+	PhysicalInstancePhaseRegistered         PhysicalInstancePhase = "Registered"
+	PhysicalInstancePhaseConnected          PhysicalInstancePhase = "Connected"
+	PhysicalInstancePhaseNotReady           PhysicalInstancePhase = "NotReady"
+)
+
+const (
+	PhysicalInstanceMulticastConnectionPhaseWaitingForConnection PhysicalInstanceMulticastConnectionPhase = "WaitingForConnection"
+	PhysicalInstanceMulticastConnectionPhaseConnecting           PhysicalInstanceMulticastConnectionPhase = "Connecting"
+	PhysicalInstanceMulticastConnectionPhaseConnected            PhysicalInstanceMulticastConnectionPhase = "Connected"
+	PhysicalInstanceMulticastConnectionPhaseFailed               PhysicalInstanceMulticastConnectionPhase = "Failed"
+)
+
+const (
+	PhysicalInstanceFederationConnectionPhaseWaitingForMulticast   PhysicalInstanceFederationConnectionPhase = "WaitingForMulticast"
+	PhysicalInstanceFederationConnectionPhaseWaitingForCredentials PhysicalInstanceFederationConnectionPhase = "WaitingForCredentials"
+	PhysicalInstanceFederationConnectionPhaseConnecting            PhysicalInstanceFederationConnectionPhase = "Connecting"
+	PhysicalInstanceFederationConnectionPhaseConnected             PhysicalInstanceFederationConnectionPhase = "Connected"
+	PhysicalInstanceFederationConnectionPhaseFailed                PhysicalInstanceFederationConnectionPhase = "Failed"
 )
 
 // PhysicalInstanceStatus defines the observed state of PhysicalInstance
 type PhysicalInstanceStatus struct {
-	Submariner       SubmarinerResourceStates       `json:"submariner,omitempty"`
-	FederationMember FederationMemberInstanceStatus `json:"federation,omitempty"`
-	Phase            PhysicalInstancePhase          `json:"phase,omitempty"`
+	Submariner                SubmarinerResourceStates                  `json:"submariner,omitempty"`
+	FederationMember          FederationMemberInstanceStatus            `json:"federation,omitempty"`
+	Phase                     PhysicalInstancePhase                     `json:"phase,omitempty"`
+	MulticastConnectionPhase  PhysicalInstanceMulticastConnectionPhase  `json:"multicastPhase,omitempty"`
+	FederationConnectionPhase PhysicalInstanceFederationConnectionPhase `json:"federationPhase,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -58,6 +75,8 @@ type PhysicalInstanceStatus struct {
 //+kubebuilder:printcolumn:name="Gateway",type=string,JSONPath=`.status.submariner.gatewayConnection.gatewayResource`
 //+kubebuilder:printcolumn:name="Hostname",type=string,JSONPath=`.status.submariner.gatewayConnection.hostname`
 //+kubebuilder:printcolumn:name="Cluster ID",type=string,JSONPath=`.status.submariner.gatewayConnection.clusterID`
+//+kubebuilder:printcolumn:name="Multicast",type=string,JSONPath=`.status.multicastPhase`
+//+kubebuilder:printcolumn:name="Federation",type=string,JSONPath=`.status.federationPhase`
 //+kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 
 // PhysicalInstance is the Schema for the physicalinstances API

--- a/config/crd/bases/connection-hub.roboscale.io_physicalinstances.yaml
+++ b/config/crd/bases/connection-hub.roboscale.io_physicalinstances.yaml
@@ -25,6 +25,12 @@ spec:
     - jsonPath: .status.submariner.gatewayConnection.clusterID
       name: Cluster ID
       type: string
+    - jsonPath: .status.multicastPhase
+      name: Multicast
+      type: string
+    - jsonPath: .status.federationPhase
+      name: Federation
+      type: string
     - jsonPath: .status.phase
       name: Phase
       type: string
@@ -100,6 +106,10 @@ spec:
                         type: string
                     type: object
                 type: object
+              federationPhase:
+                type: string
+              multicastPhase:
+                type: string
               phase:
                 type: string
               submariner:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/connection-hub-controller-manager-dev
-  newTag: v0.3.8
+  newTag: v0.3.12

--- a/controllers/federationmember_controller.go
+++ b/controllers/federationmember_controller.go
@@ -121,16 +121,26 @@ func (r *FederationMemberReconciler) reconcileCheckStatus(ctx context.Context, i
 
 		case false:
 
-			logger.Info("STATUS: Cluster " + instance.Name + " is joining the federation.")
+			switch instance.Spec.Server == "" {
+			case true:
 
-			instance.Status.Phase = connectionhubv1alpha1.FederationMemberPhaseJoiningFederation
+				instance.Status.Phase = connectionhubv1alpha1.FederationMemberPhaseWaitingForCredentials
 
-			err := utils.JoinMember(instance, r.RESTConfig)
-			if err != nil {
-				return err
+			case false:
+
+				logger.Info("STATUS: Cluster " + instance.Name + " is joining the federation.")
+
+				instance.Status.Phase = connectionhubv1alpha1.FederationMemberPhaseJoiningFederation
+
+				err := utils.JoinMember(instance, r.RESTConfig)
+				if err != nil {
+					return err
+				}
+
+				instance.Status.JoinAttempted = true
+
 			}
 
-			instance.Status.JoinAttempted = true
 		}
 
 	case false:


### PR DESCRIPTION
# :herb: PR: Sub-State to Add Federation Member Credentials

## Description

Sub-state for physical instance is added. If a physical instance is defined yet not it's server and credentials, controller sets `WaitingForCredentials` phase to physical instance.

Closes #41

## Type of change

- [x] This change requires a documentation update

## How can it be tested?

By creating a physical instance without server and credentials.
