### PR TITLE
PR: Fix Self Joining Problem of FederationHost

### DIFF
--- a/api/v1alpha1/federationmember_types.go
+++ b/api/v1alpha1/federationmember_types.go
@@ -13,6 +13,8 @@ type FederationMemberSpec struct {
 	Server string `json:"server"`
 	// +kubebuilder:validation:Required
 	Credentials PhysicalInstanceCredentials `json:"credentials"`
+
+	IsHost bool `json:"isHost,omitempty"`
 }
 
 type FederationMemberPhase string

--- a/config/crd/bases/connection-hub.roboscale.io_connectionhubs.yaml
+++ b/config/crd/bases/connection-hub.roboscale.io_connectionhubs.yaml
@@ -175,6 +175,8 @@ spec:
                           - clientCertificate
                           - clientKey
                           type: object
+                        isHost:
+                          type: boolean
                         server:
                           type: string
                       required:

--- a/config/crd/bases/connection-hub.roboscale.io_federationmembers.yaml
+++ b/config/crd/bases/connection-hub.roboscale.io_federationmembers.yaml
@@ -48,6 +48,8 @@ spec:
                 - clientCertificate
                 - clientKey
                 type: object
+              isHost:
+                type: boolean
               server:
                 type: string
             required:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: robolaunchio/connection-hub-controller-manager
-  newTag: v0.1.3
+  newName: robolaunchio/connection-hub-controller-manager-dev
+  newTag: v0.3.16

--- a/controllers/federationhost_controller.go
+++ b/controllers/federationhost_controller.go
@@ -125,6 +125,7 @@ func (r *FederationHostReconciler) reconcileCreateHostMember(ctx context.Context
 				ClientKey:            "",
 				ClientCertificate:    "",
 			},
+			IsHost: true,
 		},
 	}
 

--- a/controllers/federationmember_controller.go
+++ b/controllers/federationmember_controller.go
@@ -121,7 +121,7 @@ func (r *FederationMemberReconciler) reconcileCheckStatus(ctx context.Context, i
 
 		case false:
 
-			switch instance.Spec.Server == "" {
+			switch instance.Spec.Server == "" && !instance.Spec.IsHost {
 			case true:
 
 				instance.Status.Phase = connectionhubv1alpha1.FederationMemberPhaseWaitingForCredentials


### PR DESCRIPTION
# :herb: PR: Fix Self Joining Problem of FederationHost

## Description

Added a field to FederationMember, `spec.isHost`. FederationHost sets this field `true` while creating FederationMember

Closes #47

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update