### PR TITLE
PR: Update Tenancy Labels

### DIFF
--- a/api/v1alpha1/connectionhub_types.go
+++ b/api/v1alpha1/connectionhub_types.go
@@ -125,6 +125,10 @@ func (ch *ConnectionHub) GetTenancySelectors() *Tenancy {
 		tenancy.RobolaunchCloudInstance = cloudInstance
 	}
 
+	if cloudInstanceAlias, ok := labels[tenancy.RobolaunchCloudInstanceAlias]; ok {
+		tenancy.RobolaunchCloudInstanceAlias = cloudInstanceAlias
+	}
+
 	if physicalInstance, ok := labels[RobolaunchPhysicalInstanceLabelKey]; ok {
 		tenancy.RobolaunchPhysicalInstance = physicalInstance
 	}

--- a/api/v1alpha1/submariner_types.go
+++ b/api/v1alpha1/submariner_types.go
@@ -112,6 +112,10 @@ func (submariner *Submariner) GetTenancySelectors() *Tenancy {
 		tenancy.RobolaunchCloudInstance = cloudInstance
 	}
 
+	if cloudInstanceAlias, ok := labels[tenancy.RobolaunchCloudInstanceAlias]; ok {
+		tenancy.RobolaunchCloudInstanceAlias = cloudInstanceAlias
+	}
+
 	if physicalInstance, ok := labels[RobolaunchPhysicalInstanceLabelKey]; ok {
 		tenancy.RobolaunchPhysicalInstance = physicalInstance
 	}

--- a/api/v1alpha1/submariner_webhook.go
+++ b/api/v1alpha1/submariner_webhook.go
@@ -125,6 +125,10 @@ func (r *Submariner) checkTenancyLabelsForSubmariner() error {
 		return errors.New("cloud instance label should be added with key " + RobolaunchCloudInstanceLabelKey)
 	}
 
+	if _, ok := labels[RobolaunchCloudInstanceAliasLabelKey]; !ok {
+		return errors.New("cloud instance alias label should be added with key " + RobolaunchCloudInstanceAliasLabelKey)
+	}
+
 	return nil
 }
 

--- a/api/v1alpha1/submarinerbroker_types.go
+++ b/api/v1alpha1/submarinerbroker_types.go
@@ -86,6 +86,10 @@ func (smb *SubmarinerBroker) GetTenancySelectors() *Tenancy {
 		tenancy.RobolaunchCloudInstance = cloudInstance
 	}
 
+	if cloudInstanceAlias, ok := labels[tenancy.RobolaunchCloudInstanceAlias]; ok {
+		tenancy.RobolaunchCloudInstanceAlias = cloudInstanceAlias
+	}
+
 	return tenancy
 }
 

--- a/api/v1alpha1/submarinerbroker_webhook.go
+++ b/api/v1alpha1/submarinerbroker_webhook.go
@@ -69,6 +69,10 @@ func (r *SubmarinerBroker) checkTenancyLabelsForSMB() error {
 		return errors.New("cloud instance label should be added with key " + RobolaunchCloudInstanceLabelKey)
 	}
 
+	if _, ok := labels[RobolaunchCloudInstanceAliasLabelKey]; !ok {
+		return errors.New("cloud instance alias label should be added with key " + RobolaunchCloudInstanceLabelKey)
+	}
+
 	if _, ok := labels[RobolaunchPhysicalInstanceLabelKey]; ok {
 		return errors.New("cloud instance label should be empty for submariner broker")
 	}

--- a/api/v1alpha1/submarineroperator_types.go
+++ b/api/v1alpha1/submarineroperator_types.go
@@ -104,6 +104,10 @@ func (so *SubmarinerOperator) GetTenancySelectors() *Tenancy {
 		tenancy.RobolaunchCloudInstance = cloudInstance
 	}
 
+	if cloudInstanceAlias, ok := labels[RobolaunchCloudInstanceAliasLabelKey]; ok {
+		tenancy.RobolaunchCloudInstanceAlias = cloudInstanceAlias
+	}
+
 	if physicalInstance, ok := labels[RobolaunchPhysicalInstanceLabelKey]; ok {
 		tenancy.RobolaunchPhysicalInstance = physicalInstance
 	}

--- a/api/v1alpha1/submarineroperator_webhook.go
+++ b/api/v1alpha1/submarineroperator_webhook.go
@@ -68,5 +68,9 @@ func (r *SubmarinerOperator) checkTenancyLabelsForSO() error {
 		return errors.New("cloud instance label should be added with key " + RobolaunchCloudInstanceLabelKey)
 	}
 
+	if _, ok := labels[RobolaunchCloudInstanceAliasLabelKey]; !ok {
+		return errors.New("cloud instance alias label should be added with key " + RobolaunchCloudInstanceAliasLabelKey)
+	}
+
 	return nil
 }

--- a/api/v1alpha1/tenancy.go
+++ b/api/v1alpha1/tenancy.go
@@ -1,12 +1,14 @@
 package v1alpha1
 
 const (
-	RobolaunchCloudInstanceLabelKey    = "robolaunch.io/cloud-instance"
-	RobolaunchPhysicalInstanceLabelKey = "robolaunch.io/physical-instance"
+	RobolaunchCloudInstanceLabelKey      = "robolaunch.io/cloud-instance"
+	RobolaunchCloudInstanceAliasLabelKey = "robolaunch.io/cloud-instance-alias"
+	RobolaunchPhysicalInstanceLabelKey   = "robolaunch.io/physical-instance"
 )
 
 // Not used in robot manifest, needed for internal use.
 type Tenancy struct {
-	RobolaunchCloudInstance    string `json:"cloudInstance,omitempty"`
-	RobolaunchPhysicalInstance string `json:"physicalInstance,omitempty"`
+	RobolaunchCloudInstance      string `json:"cloudInstance,omitempty"`
+	RobolaunchCloudInstanceAlias string `json:"cloudInstanceAlias,omitempty"`
+	RobolaunchPhysicalInstance   string `json:"physicalInstance,omitempty"`
 }

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/connection-hub-controller-manager
-  newTag: v0.1.4
+  newTag: v0.1.5

--- a/hack/deploy/connection_hub_operator.yaml
+++ b/hack/deploy/connection_hub_operator.yaml
@@ -4171,7 +4171,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: robolaunchio/connection-hub-controller-manager:v0.1.4
+          image: robolaunchio/connection-hub-controller-manager:v0.1.5
           livenessProbe:
             httpGet:
               path: /healthz
@@ -4218,8 +4218,8 @@ spec:
         robolaunch.io/organization: robolaunch
         robolaunch.io/team: robotics
         robolaunch.io/region: europe-east
-        robolaunch.io/buffer-instance: buffer
         robolaunch.io/cloud-instance: cluster
+        robolaunch.io/cloud-instance-alias: cluster-alias
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -10,5 +10,5 @@ make docker-build docker-push gh-extract IMG=robolaunchio/connection-hub-control
 make gh-select-node LABEL_KEY="robolaunch.io/organization" LABEL_VAL="robolaunch"
 make gh-select-node LABEL_KEY="robolaunch.io/team" LABEL_VAL="robotics"
 make gh-select-node LABEL_KEY="robolaunch.io/region" LABEL_VAL="europe-east"
-make gh-select-node LABEL_KEY="robolaunch.io/buffer-instance" LABEL_VAL="buffer"
 make gh-select-node LABEL_KEY="robolaunch.io/cloud-instance" LABEL_VAL="cluster"
+make gh-select-node LABEL_KEY="robolaunch.io/cloud-instance-alias" LABEL_VAL="cluster-alias"


### PR DESCRIPTION
# :herb: PR: Update Tenancy Labels

## Description

Related to robolaunch/robot-operator#62

- Label for buffer instance is removed
- Label for cloud instance alias is added

Closes #49

## Type of change

- [x] This change requires a documentation update