### PR TITLE
PR: Set Custom CoreDNS Config for Submariner Operator Helm Chart

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/connection-hub-controller-manager
-  newTag: v0.1.7-alpha.10
+  newTag: v0.1.7-alpha.11

--- a/controllers/pkg/helm/submariner_operator_values.go
+++ b/controllers/pkg/helm/submariner_operator_values.go
@@ -4,17 +4,21 @@ import (
 	connectionhubv1alpha1 "github.com/robolaunch/connection-hub-operator/api/v1alpha1"
 )
 
-type CoreDNSCustomConfig struct{}
-
 type Submariner struct {
-	ClusterID          string `yaml:"clusterId"`
-	ClusterCIDR        string `yaml:"clusterCidr"`
-	ServiceCIDR        string `yaml:"serviceCidr"`
-	NatEnabled         bool   `yaml:"natEnabled"`
-	ServiceDiscovery   bool   `yaml:"serviceDiscovery"`
-	CableDriver        string `yaml:"cableDriver"`
-	HealthCheckEnabled bool   `yaml:"healthcheckEnabled"`
-	GlobalCIDR         string `yaml:"globalCidr"`
+	ClusterID           string              `yaml:"clusterId"`
+	ClusterCIDR         string              `yaml:"clusterCidr"`
+	ServiceCIDR         string              `yaml:"serviceCidr"`
+	NatEnabled          bool                `yaml:"natEnabled"`
+	ServiceDiscovery    bool                `yaml:"serviceDiscovery"`
+	CableDriver         string              `yaml:"cableDriver"`
+	HealthCheckEnabled  bool                `yaml:"healthcheckEnabled"`
+	GlobalCIDR          string              `yaml:"globalCidr"`
+	CoreDNSCustomConfig CoreDNSCustomConfig `yaml:"coreDNSCustomConfig"`
+}
+
+type CoreDNSCustomConfig struct {
+	ConfigMapName string `yaml:"configMapName"`
+	Namespace     string `yaml:"namespace"`
 }
 
 func getSubmarinerDefault() Submariner {
@@ -27,6 +31,10 @@ func getSubmarinerDefault() Submariner {
 		CableDriver:        "wireguard",
 		HealthCheckEnabled: true,
 		GlobalCIDR:         "",
+		CoreDNSCustomConfig: CoreDNSCustomConfig{
+			ConfigMapName: "coredns-coredns",
+			Namespace:     "coredns",
+		},
 	}
 }
 

--- a/hack/deploy/chart/connection-hub-operator/Chart.yaml
+++ b/hack/deploy/chart/connection-hub-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7-alpha.10
+version: 0.1.7-alpha.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.7-alpha.10"
+appVersion: "v0.1.7-alpha.11"

--- a/hack/deploy/chart/connection-hub-operator/values.yaml
+++ b/hack/deploy/chart/connection-hub-operator/values.yaml
@@ -32,7 +32,7 @@ controllerManager:
         - ALL
     image:
       repository: robolaunchio/connection-hub-controller-manager
-      tag: v0.1.7-alpha.10
+      tag: v0.1.7-alpha.11
     resources:
       limits:
         cpu: 500m

--- a/hack/deploy/manifests/connection_hub_operator.yaml
+++ b/hack/deploy/manifests/connection_hub_operator.yaml
@@ -4357,7 +4357,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: robolaunchio/connection-hub-controller-manager:v0.1.7-alpha.10
+          image: robolaunchio/connection-hub-controller-manager:v0.1.7-alpha.11
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
# :herb: PR: Set Custom CoreDNS Config for Submariner Operator Helm Chart

## Description

- CoreDNS config map name: `coredns-coredns`
- CoreDNS config map namespace: `coredns`

Closes #69 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)