### PR TITLE
PR: Recreate ServiceExports in Reboot

### DIFF
--- a/api/v1alpha1/cloudinstance_types.go
+++ b/api/v1alpha1/cloudinstance_types.go
@@ -55,6 +55,7 @@ type CloudInstanceStatus struct {
 	ConnectionResources ConnectionResourceStatuses `json:"connectionResources,omitempty"`
 	GatewayConnection   GatewayConnection          `json:"gatewayConnection,omitempty"`
 	Phase               CloudInstancePhase         `json:"phase,omitempty"`
+	BootID              string                     `json:"bootID,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/physicalinstance_types.go
+++ b/api/v1alpha1/physicalinstance_types.go
@@ -87,6 +87,7 @@ type PhysicalInstanceStatus struct {
 	RelayServerPodStatus      RelayServerPodStatus                      `json:"relayServerPodStatus,omitempty"`
 	RelayServerServiceStatus  RelayServerServiceStatus                  `json:"relayServerServiceStatus,omitempty"`
 	ConnectionURL             string                                    `json:"connectionURL,omitempty"`
+	BootID                    string                                    `json:"bootID,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/tenancy.go
+++ b/api/v1alpha1/tenancy.go
@@ -4,7 +4,6 @@ const (
 	RobolaunchCloudInstanceLabelKey      = "robolaunch.io/cloud-instance"
 	RobolaunchCloudInstanceAliasLabelKey = "robolaunch.io/cloud-instance-alias"
 	RobolaunchPhysicalInstanceLabelKey   = "robolaunch.io/physical-instance"
-	RobolaunchBootIDLabelKey             = "robolaunch.io/boot-id"
 )
 
 // Not used in robot manifest, needed for internal use.

--- a/api/v1alpha1/tenancy.go
+++ b/api/v1alpha1/tenancy.go
@@ -1,5 +1,7 @@
 package v1alpha1
 
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 const (
 	RobolaunchCloudInstanceLabelKey      = "robolaunch.io/cloud-instance"
 	RobolaunchCloudInstanceAliasLabelKey = "robolaunch.io/cloud-instance-alias"
@@ -11,4 +13,23 @@ type Tenancy struct {
 	RobolaunchCloudInstance      string `json:"cloudInstance,omitempty"`
 	RobolaunchCloudInstanceAlias string `json:"cloudInstanceAlias,omitempty"`
 	RobolaunchPhysicalInstance   string `json:"physicalInstance,omitempty"`
+}
+
+func GetTenancyMap(obj metav1.Object) map[string]string {
+	labels := obj.GetLabels()
+	tenancyMap := make(map[string]string)
+
+	if cloudInstance, ok := labels[RobolaunchCloudInstanceLabelKey]; ok {
+		tenancyMap[RobolaunchCloudInstanceLabelKey] = cloudInstance
+	}
+
+	if cloudInstanceAlias, ok := labels[RobolaunchCloudInstanceAliasLabelKey]; ok {
+		tenancyMap[RobolaunchCloudInstanceAliasLabelKey] = cloudInstanceAlias
+	}
+
+	if physicalInstance, ok := labels[RobolaunchPhysicalInstanceLabelKey]; ok {
+		tenancyMap[RobolaunchPhysicalInstanceLabelKey] = physicalInstance
+	}
+
+	return tenancyMap
 }

--- a/api/v1alpha1/tenancy.go
+++ b/api/v1alpha1/tenancy.go
@@ -4,6 +4,7 @@ const (
 	RobolaunchCloudInstanceLabelKey      = "robolaunch.io/cloud-instance"
 	RobolaunchCloudInstanceAliasLabelKey = "robolaunch.io/cloud-instance-alias"
 	RobolaunchPhysicalInstanceLabelKey   = "robolaunch.io/physical-instance"
+	RobolaunchBootIDLabelKey             = "robolaunch.io/boot-id"
 )
 
 // Not used in robot manifest, needed for internal use.

--- a/controllers/pkg/error/error.go
+++ b/controllers/pkg/error/error.go
@@ -1,0 +1,40 @@
+package error
+
+import (
+	"fmt"
+)
+
+// Throwed when certain labels cannot be found on a resource.
+type LabelNotFoundError struct {
+	Err               error
+	LabelKey          string
+	ResourceKind      string
+	ResourceName      string
+	ResourceNamespace string
+}
+
+func (r *LabelNotFoundError) Error() string {
+	return fmt.Sprintf("label with key %v is not found in resource %v %v in the namespace %v", r.LabelKey, r.ResourceKind, r.ResourceName, r.ResourceNamespace)
+}
+
+type NodeNotFoundError struct {
+	Err               error
+	ResourceKind      string
+	ResourceName      string
+	ResourceNamespace string
+}
+
+func (r *NodeNotFoundError) Error() string {
+	return fmt.Sprintf("no available node for resource %v %v in namespace %v", r.ResourceKind, r.ResourceName, r.ResourceNamespace)
+}
+
+type MultipleNodeFoundError struct {
+	Err               error
+	ResourceKind      string
+	ResourceName      string
+	ResourceNamespace string
+}
+
+func (r *MultipleNodeFoundError) Error() string {
+	return fmt.Sprintf("multiple nodes are found for resource %v %v in namespace %v", r.ResourceKind, r.ResourceName, r.ResourceNamespace)
+}


### PR DESCRIPTION
# :herb: PR: Recreate ServiceExports in Reboot

## Description

ServiceExports are recreated in two situations:
- CI/PI phase goes from any other state to "Connected" state.
- CI/PI are rebooted.

Closes #71 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How can it be tested?

Can be tested with reboot tests.
