### PR TITLE
PR: Switch Submariner's Cable Driver to Libreswan 

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/connection-hub-controller-manager
-  newTag: v0.1.7-alpha.12-libreswan
+  newTag: v0.1.7-alpha.12-libreswan-v2

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/connection-hub-controller-manager
-  newTag: v0.1.7-alpha.12
+  newTag: v0.1.7-alpha.12-libreswan

--- a/controllers/pkg/helm/submariner_operator_values.go
+++ b/controllers/pkg/helm/submariner_operator_values.go
@@ -125,7 +125,7 @@ func GetSubmarinerOperatorValues(submarinerOperator connectionhubv1alpha1.Submar
 	valuesObj.Broker.Ca = submarinerOperator.Spec.BrokerCredentials.CA
 	valuesObj.Broker.Insecure = true
 	valuesObj.Submariner.ServiceDiscovery = true
-	valuesObj.Submariner.CableDriver = "wireguard"
+	valuesObj.Submariner.CableDriver = "libreswan"
 	valuesObj.Submariner.ClusterID = submarinerOperator.Spec.ClusterID
 	valuesObj.Submariner.NatEnabled = submarinerOperator.Spec.NetworkType == connectionhubv1alpha1.NetworkTypeExternal
 	valuesObj.ServiceAccounts.LighthouseAgent.Create = true

--- a/controllers/pkg/helm/submariner_operator_values.go
+++ b/controllers/pkg/helm/submariner_operator_values.go
@@ -5,15 +5,15 @@ import (
 )
 
 type Submariner struct {
-	ClusterID           string              `yaml:"clusterId"`
-	ClusterCIDR         string              `yaml:"clusterCidr"`
-	ServiceCIDR         string              `yaml:"serviceCidr"`
-	NatEnabled          bool                `yaml:"natEnabled"`
-	ServiceDiscovery    bool                `yaml:"serviceDiscovery"`
-	CableDriver         string              `yaml:"cableDriver"`
-	HealthCheckEnabled  bool                `yaml:"healthcheckEnabled"`
-	GlobalCIDR          string              `yaml:"globalCidr"`
-	CoreDNSCustomConfig CoreDNSCustomConfig `yaml:"coreDNSCustomConfig"`
+	ClusterID          string `yaml:"clusterId"`
+	ClusterCIDR        string `yaml:"clusterCidr"`
+	ServiceCIDR        string `yaml:"serviceCidr"`
+	NatEnabled         bool   `yaml:"natEnabled"`
+	ServiceDiscovery   bool   `yaml:"serviceDiscovery"`
+	CableDriver        string `yaml:"cableDriver"`
+	HealthCheckEnabled bool   `yaml:"healthcheckEnabled"`
+	// GlobalCIDR         string `yaml:"globalCidr"`
+	// CoreDNSCustomConfig CoreDNSCustomConfig `yaml:"coreDNSCustomConfig"`
 }
 
 type CoreDNSCustomConfig struct {
@@ -30,7 +30,7 @@ func getSubmarinerDefault() Submariner {
 		ServiceDiscovery:   true,
 		CableDriver:        "libreswan",
 		HealthCheckEnabled: true,
-		GlobalCIDR:         "",
+		// GlobalCIDR:         "",
 		// not a safe way to indicate CoreDNS
 		// CoreDNSCustomConfig: CoreDNSCustomConfig{
 		// 	ConfigMapName: "coredns-coredns",
@@ -43,9 +43,9 @@ type Broker struct {
 	Server    string `yaml:"server"`
 	Token     string `yaml:"token"`
 	Namespace string `yaml:"namespace"`
-	Insecure  bool   `yaml:"insecure"`
-	Ca        string `yaml:"ca"`
-	GlobalNet string `yaml:"globalnet"`
+	// Insecure  bool   `yaml:"insecure"`
+	Ca string `yaml:"ca"`
+	// GlobalNet string `yaml:"globalnet"`
 }
 
 func getBrokerDefault() Broker {
@@ -53,9 +53,9 @@ func getBrokerDefault() Broker {
 		Server:    "example.k8s.apiserver",
 		Token:     "test",
 		Namespace: "xyz",
-		Insecure:  false,
-		Ca:        "",
-		GlobalNet: "",
+		// Insecure:  false,
+		Ca: "",
+		// GlobalNet: "",
 	}
 }
 
@@ -78,16 +78,16 @@ type ServiceAccountGlobalNet struct {
 }
 
 type ServiceAccounts struct {
-	GlobalNet         ServiceAccountGlobalNet `yaml:"globalnet"`
-	LighthouseAgent   ServiceAccount          `yaml:"lighthouseAgent"`
-	LighthouseCoreDNS ServiceAccount          `yaml:"lighthouseCoreDns"`
+	// GlobalNet         ServiceAccountGlobalNet `yaml:"globalnet"`
+	LighthouseAgent   ServiceAccount `yaml:"lighthouseAgent"`
+	LighthouseCoreDNS ServiceAccount `yaml:"lighthouseCoreDns"`
 }
 
 func getServiceAccountsDefault() ServiceAccounts {
 	return ServiceAccounts{
-		GlobalNet: ServiceAccountGlobalNet{
-			Create: "",
-		},
+		// GlobalNet: ServiceAccountGlobalNet{
+		// 	Create: "",
+		// },
 		LighthouseAgent: ServiceAccount{
 			Create: true,
 		},
@@ -123,7 +123,7 @@ func GetSubmarinerOperatorValues(submarinerOperator connectionhubv1alpha1.Submar
 	valuesObj.Broker.Server = submarinerOperator.Spec.APIServerURL
 	valuesObj.Broker.Token = submarinerOperator.Spec.BrokerCredentials.Token
 	valuesObj.Broker.Ca = submarinerOperator.Spec.BrokerCredentials.CA
-	valuesObj.Broker.Insecure = true
+	// valuesObj.Broker.Insecure = true
 	valuesObj.Submariner.ServiceDiscovery = true
 	valuesObj.Submariner.CableDriver = "libreswan"
 	valuesObj.Submariner.ClusterID = submarinerOperator.Spec.ClusterID

--- a/controllers/pkg/helm/submariner_operator_values.go
+++ b/controllers/pkg/helm/submariner_operator_values.go
@@ -28,7 +28,7 @@ func getSubmarinerDefault() Submariner {
 		ServiceCIDR:        "",
 		NatEnabled:         true,
 		ServiceDiscovery:   true,
-		CableDriver:        "wireguard",
+		CableDriver:        "libreswan",
 		HealthCheckEnabled: true,
 		GlobalCIDR:         "",
 		// not a safe way to indicate CoreDNS

--- a/hack/deploy/chart/connection-hub-operator/Chart.yaml
+++ b/hack/deploy/chart/connection-hub-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7-alpha.12-libreswan
+version: 0.1.7-alpha.12-libreswan-v2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.7-alpha.12-libreswan"
+appVersion: "v0.1.7-alpha.12-libreswan-v2"

--- a/hack/deploy/chart/connection-hub-operator/Chart.yaml
+++ b/hack/deploy/chart/connection-hub-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7-alpha.12
+version: 0.1.7-alpha.12-libreswan
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.7-alpha.12"
+appVersion: "v0.1.7-alpha.12-libreswan"

--- a/hack/deploy/chart/connection-hub-operator/values.yaml
+++ b/hack/deploy/chart/connection-hub-operator/values.yaml
@@ -32,7 +32,7 @@ controllerManager:
         - ALL
     image:
       repository: robolaunchio/connection-hub-controller-manager
-      tag: v0.1.7-alpha.12-libreswan
+      tag: v0.1.7-alpha.12-libreswan-v2
     resources:
       limits:
         cpu: 500m

--- a/hack/deploy/chart/connection-hub-operator/values.yaml
+++ b/hack/deploy/chart/connection-hub-operator/values.yaml
@@ -32,7 +32,7 @@ controllerManager:
         - ALL
     image:
       repository: robolaunchio/connection-hub-controller-manager
-      tag: v0.1.7-alpha.12
+      tag: v0.1.7-alpha.12-libreswan
     resources:
       limits:
         cpu: 500m

--- a/hack/deploy/manifests/connection_hub_operator.yaml
+++ b/hack/deploy/manifests/connection_hub_operator.yaml
@@ -4361,7 +4361,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: robolaunchio/connection-hub-controller-manager:v0.1.7-alpha.12
+          image: robolaunchio/connection-hub-controller-manager:v0.1.7-alpha.12-libreswan
           livenessProbe:
             httpGet:
               path: /healthz

--- a/hack/deploy/manifests/connection_hub_operator.yaml
+++ b/hack/deploy/manifests/connection_hub_operator.yaml
@@ -4361,7 +4361,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: robolaunchio/connection-hub-controller-manager:v0.1.7-alpha.12-libreswan
+          image: robolaunchio/connection-hub-controller-manager:v0.1.7-alpha.12-libreswan-v2
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
# :herb: PR: Switch Submariner's Cable Driver to Libreswan 

## Description

- `libreswan` is now being used by Submariner.
- Redundant fields are removed.

## Type of change

- [x] This change requires a documentation update