### PR TITLE
PR: Make Cable Driver Selectable

### DIFF
--- a/api/v1alpha1/submarineroperator_types.go
+++ b/api/v1alpha1/submarineroperator_types.go
@@ -52,6 +52,10 @@ type SubmarinerOperatorSpec struct {
 	HelmRepository HelmRepository `json:"helmRepository"`
 	// +kubebuilder:validation:Required
 	HelmChart HelmChart `json:"helmChart"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=libreswan;wireguard
+	// +kubebuilder:default="libreswan"
+	CableDriver string `json:"cableDriver"`
 }
 
 type SubmarinerOperatorPhase string

--- a/controllers/pkg/helm/submariner_operator_values.go
+++ b/controllers/pkg/helm/submariner_operator_values.go
@@ -28,7 +28,7 @@ func getSubmarinerDefault() Submariner {
 		ServiceCIDR:        "",
 		NatEnabled:         true,
 		ServiceDiscovery:   true,
-		CableDriver:        "libreswan",
+		CableDriver:        "libreswan", // or wireguard
 		HealthCheckEnabled: true,
 		// GlobalCIDR:         "",
 		// not a safe way to indicate CoreDNS
@@ -125,7 +125,7 @@ func GetSubmarinerOperatorValues(submarinerOperator connectionhubv1alpha1.Submar
 	valuesObj.Broker.Ca = submarinerOperator.Spec.BrokerCredentials.CA
 	// valuesObj.Broker.Insecure = true
 	valuesObj.Submariner.ServiceDiscovery = true
-	valuesObj.Submariner.CableDriver = "libreswan"
+	valuesObj.Submariner.CableDriver = submarinerOperator.Spec.CableDriver
 	valuesObj.Submariner.ClusterID = submarinerOperator.Spec.ClusterID
 	valuesObj.Submariner.NatEnabled = submarinerOperator.Spec.NetworkType == connectionhubv1alpha1.NetworkTypeExternal
 	valuesObj.ServiceAccounts.LighthouseAgent.Create = true

--- a/controllers/pkg/helm/submariner_operator_values.go
+++ b/controllers/pkg/helm/submariner_operator_values.go
@@ -43,8 +43,8 @@ type Broker struct {
 	Server    string `yaml:"server"`
 	Token     string `yaml:"token"`
 	Namespace string `yaml:"namespace"`
-	// Insecure  bool   `yaml:"insecure"`
-	Ca string `yaml:"ca"`
+	Insecure  bool   `yaml:"insecure"`
+	Ca        string `yaml:"ca"`
 	// GlobalNet string `yaml:"globalnet"`
 }
 
@@ -123,7 +123,7 @@ func GetSubmarinerOperatorValues(submarinerOperator connectionhubv1alpha1.Submar
 	valuesObj.Broker.Server = submarinerOperator.Spec.APIServerURL
 	valuesObj.Broker.Token = submarinerOperator.Spec.BrokerCredentials.Token
 	valuesObj.Broker.Ca = submarinerOperator.Spec.BrokerCredentials.CA
-	// valuesObj.Broker.Insecure = true
+	valuesObj.Broker.Insecure = true
 	valuesObj.Submariner.ServiceDiscovery = true
 	valuesObj.Submariner.CableDriver = submarinerOperator.Spec.CableDriver
 	valuesObj.Submariner.ClusterID = submarinerOperator.Spec.ClusterID


### PR DESCRIPTION
# :herb: PR: Make Cable Driver Selectable

## Description

- Cable driver is added to the API
- Insecure connections to the broker are allowed

Closes #74 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How can it be tested?

Can be tested by creating a `SubmarinerOperator` resource with it's field `.spec.cableDriver` is set to either `wireguard` or `libreswan`.
